### PR TITLE
call parent constructor in Multimeter\Constraint\ThrowsException

### DIFF
--- a/php/classes/Multimeter/Constraint/ThrowsException.php
+++ b/php/classes/Multimeter/Constraint/ThrowsException.php
@@ -21,6 +21,7 @@ class ThrowsException extends PHPUnit_Framework_Constraint
      */
     public function __construct($expectedException)
     {
+        parent::__construct();
         if (empty($expectedException)) {
             
         } if (is_string($expectedException)) {


### PR DESCRIPTION
Hello, kuzuha.

AssertThrowExcpetion has a pretty bug.
PHP Fatal error occur when don't throw exception from callback.

```
PHP Fatal error:  Call to a member function export() on a non-object in ~/work/multimeter/vendor/phpunit/phpunit/src/Framework/Constraint.php on line 186
```
